### PR TITLE
fix text position

### DIFF
--- a/src/delegates/LabelDelegate.js
+++ b/src/delegates/LabelDelegate.js
@@ -215,8 +215,8 @@ Ext.define('GraphicDesigner.LabelDelegate', {
 		var rect = this.getTextRect();
 		var position = $(this.view.ownerCt.paper.canvas).position();
 		this.textHolder.css({
-			left : position.left + rect.x,
-			top : position.top + rect.y,
+			left : rect.x,
+			top : rect.y,
 			width : rect.width,
 			height : rect.height
 		});


### PR DESCRIPTION
text position not correct when double clicked.
![text_position](https://cloud.githubusercontent.com/assets/4877513/13666156/0dd9cef4-e6eb-11e5-95fc-506995e50471.png)
